### PR TITLE
fix: Use raw GitHub URL for architecture diagram embedding

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -25,7 +25,7 @@ The **development server** is the cornerstone of AdvanceWeekly's development wor
 
 ## System Architecture Diagram
 
-![System Architecture](docs/architecture-diagram.svg)
+![System Architecture](https://raw.githubusercontent.com/diegoln/snippets/main/docs/architecture-diagram.svg)
 
 The diagram illustrates the layered architecture with clear separation between:
 - **User Interface Layer**: Landing page, snippets, performance assessments, and integration management


### PR DESCRIPTION
## Summary

Fixes issue #15 where the architecture diagram was not displaying in the README/documentation on GitHub.

## Problem

GitHub cannot render SVG files referenced via relative paths in Markdown for security reasons. The current reference:

Results in a broken image link on GitHub.

## Solution

Replace the relative path with a raw GitHub URL that GitHub can properly render:


## Changes Made

- Updated  to use  URL for the SVG diagram
- Ensures the diagram displays correctly on GitHub while maintaining the SVG file in the repository

## Testing

The diagram should now render properly when viewing the architecture documentation on GitHub.

Resolves #15

🤖 Generated with [Claude Code](https://claude.ai/code)