### PR TITLE
Fix broken logo display on landing page

### DIFF
--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -53,7 +53,7 @@ export function LandingPage() {
         {/* Hero Section */}
         <div className="text-center mb-16">
           <div className="flex justify-center mb-8">
-            <Logo variant="horizontal" width={320} className="w-64 sm:w-80 lg:w-96" priority />
+            <Logo variant="horizontal" className="w-64 sm:w-80 lg:w-96" priority />
           </div>
           
           <h1 className="text-3xl sm:text-4xl lg:text-5xl xl:text-6xl font-bold text-primary-600 mb-6 leading-tight">

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -103,7 +103,7 @@ export const Logo: React.FC<LogoProps> = ({
         priority={priority}
         className="logo-image"
         style={{
-          width: `${logoWidth}px`,
+          width: width ? `${logoWidth}px` : '100%',
           height: 'auto',
           maxWidth: '100%',
         }}


### PR DESCRIPTION
## Summary
- Fix logo appearing broken on the landing page due to CSS conflicts
- Resolve conflict between width prop and Tailwind responsive classes
- Ensure logo displays properly across all screen sizes

## Problem
The logo was broken because of a conflict between:
- Fixed `width={320}` prop setting inline styles `width: 320px`  
- Responsive Tailwind classes `w-64 sm:w-80 lg:w-96` trying to control width
- This caused the logo to not display correctly

## Solution
- **Removed** conflicting `width={320}` prop from Logo component call in LandingPage
- **Updated** Logo component to use `width: '100%'` when no width prop is provided
- **Allow** Tailwind responsive classes to fully control the sizing behavior
- **Maintain** proper responsive scaling: 256px → 320px → 384px across breakpoints

## Changes Made
1. **LandingPage.tsx**: Remove `width={320}` prop from Logo component
2. **Logo.tsx**: Update inline styles to use `width: '100%'` when no width prop provided

## Test Plan
- [x] Verify logo displays correctly on mobile (320-768px)
- [x] Test logo appearance on tablet (768-1024px)  
- [x] Confirm logo works on desktop (1024px+)
- [x] Check development server shows logo properly
- [x] Validate responsive scaling works as expected

## Technical Details
The fix ensures that when no `width` prop is provided, the Logo component defers to CSS classes for sizing control, preventing the inline style override that was breaking the display.

🤖 Generated with [Claude Code](https://claude.ai/code)