### PR TITLE
fix: Upgrade from Gemini 1.5-flash to 2.5-flash and remove logging truncation

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -5,4 +5,4 @@ NEXTAUTH_URL="http://localhost:3000"
 # Google Gemini API Configuration
 # Get your API key from: https://aistudio.google.com/app/apikey
 # GEMINI_API_KEY="your-gemini-api-key-here"
-GEMINI_MODEL="gemini-1.5-flash"
+GEMINI_MODEL="gemini-2.5-flash"

--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ TODOIST_CLIENT_SECRET="your-todoist-client-secret"
 # AWS API Gateway (for production)
 AWS_API_ENDPOINT="https://your-api-gateway-url.amazonaws.com/prod"
 
-# LLM Configuration
-LLM_PROVIDER="ollama"  # or "mock" for testing
-OLLAMA_API_URL="http://localhost:11434"
-OLLAMA_MODEL="smollm2:1.7b"
+# Google Gemini API Configuration
+# Get your API key from: https://aistudio.google.com/app/apikey
+GEMINI_API_KEY="your-gemini-api-key-here"
+GEMINI_MODEL="gemini-2.5-flash"

--- a/lib/llmproxy.ts
+++ b/lib/llmproxy.ts
@@ -106,7 +106,7 @@ export class LLMProxyClient {
         console.log('Prompt Length:', prompt.length, 'characters')
         console.log('-'.repeat(40))
         console.log('PROMPT:')
-        console.log(prompt.substring(0, 500) + (prompt.length > 500 ? '...[truncated]' : ''))
+        console.log(prompt)
         console.log('='.repeat(80) + '\n')
 
         const timeoutPromise = new Promise((_, reject) => {
@@ -129,7 +129,7 @@ export class LLMProxyClient {
         console.log('Tokens Used:', response.usageMetadata?.totalTokenCount || 'unknown')
         console.log('-'.repeat(40))
         console.log('RESPONSE:')
-        console.log(text?.substring(0, 500) + (text?.length > 500 ? '...[truncated]' : ''))
+        console.log(text)
         console.log('='.repeat(80) + '\n')
 
         // Check for empty response - might indicate model or content filtering issues


### PR DESCRIPTION
## Summary

Upgrade GEMINI_MODEL configuration from `gemini-1.5-flash` to `gemini-2.5-flash` for improved performance, reliability, and response quality.

• Update `.env.development` to use `gemini-2.5-flash`
• Update `.env.example` to replace Ollama config with proper Gemini 2.5-flash configuration  
• Remove logging truncation in `llmproxy.ts` for better debugging visibility

## Benefits

• **Better Performance**: Faster and more accurate responses with Gemini 2.5-flash
• **Improved Reliability**: Fewer 503 server overload errors compared to 1.5-flash
• **Enhanced Quality**: Better reasoning capabilities and response quality
• **Full Debugging**: Complete LLM prompt/response logging without truncation

## Test Plan

- [x] Environment configuration updated correctly
- [x] Pre-commit hooks pass successfully  
- [x] Development checks pass (`npm run check:dev`)
- [x] No breaking changes to existing functionality
- [ ] Restart dev server to verify new model is being used
- [ ] Confirm debug logs show `Model: gemini-2.5-flash`

## Resolves

Fixes #74

🤖 Generated with [Claude Code](https://claude.ai/code)