### PR TITLE
feat: Extend OAuth scopes for comprehensive Google Workspace access

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -101,6 +101,14 @@ const handleJWT = async (params: any) => {
     provider: account?.provider,
   });
   
+  // Store Google OAuth tokens for batch processing
+  if (account?.provider === 'google') {
+    token.accessToken = account.access_token
+    token.refreshToken = account.refresh_token
+    token.expiresAt = account.expires_at
+    authLog('Stored Google OAuth tokens with extended scopes')
+  }
+  
   if (user && 'id' in user) {
     token.sub = user.id
   }
@@ -157,8 +165,19 @@ const providers = process.env.NODE_ENV === 'development'
               "openid",
               "email", 
               "profile",
-              "https://www.googleapis.com/auth/calendar.readonly"
-            ].join(" ")
+              // Calendar API - for event metadata
+              "https://www.googleapis.com/auth/calendar.readonly",
+              // Meet API - for transcripts and recordings
+              "https://www.googleapis.com/auth/meetings.space.readonly",
+              // Drive API - for accessing meeting artifacts stored in Drive
+              "https://www.googleapis.com/auth/drive.readonly",
+              // Docs API - for accessing meeting notes and AI-generated summaries
+              "https://www.googleapis.com/auth/documents.readonly"
+            ].join(" "),
+            // Request offline access for refresh tokens (batch processing)
+            access_type: "offline",
+            // Force consent screen to ensure we get refresh token
+            prompt: "consent"
           }
         }
       })


### PR DESCRIPTION
## Summary
Extends Google OAuth scopes to enable comprehensive access to Google Workspace data in a single user authorization.

## Changes
- 🔐 Added Google Meet API scope for transcript and recording access
- 📁 Added Google Drive API scope for meeting artifact retrieval
- 📄 Added Google Docs API scope for AI-generated meeting notes
- 🔄 Configured offline access and consent prompt for refresh tokens
- 💾 Updated JWT callback to properly store extended OAuth tokens

## User Impact
Users will now see a single consent screen requesting access to:
- Calendar events (existing)
- Meet conference data (new)
- Drive files (new)
- Docs documents (new)

This is a **one-time reauthorization** - existing users will need to reconnect their Google account to grant the extended permissions.

## Technical Details
The extended scopes enable future batch processing capabilities for:
- Meeting transcripts from Google Meet
- AI-generated summaries from "Take Notes for Me" 
- Related documents and presentations from Drive
- Rich context for career development insights

## Testing
- [x] Pre-commit checks pass
- [x] TypeScript compilation successful
- [x] ESLint validation complete
- [x] API contract validation passes
- [x] All tests passing

## Next Steps
After merge, we can implement batch processing services that leverage these extended permissions to provide richer meeting context for the consolidation pipeline.

🤖 Generated with [Claude Code](https://claude.ai/code)