### PR TITLE
Fix: Clarify current vs target level in career guidelines prompts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,6 +29,9 @@ build.log
 *.sqlite3
 prisma/dev.db
 
+# Mock datasets (dev/test only)
+data/mock-datasets/
+
 # IDE and editor files
 .vscode/
 .idea/

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -34,6 +34,9 @@ server.log
 *.sqlite3
 prisma/dev.db
 
+# Mock datasets (dev/test only)
+data/mock-datasets/
+
 # IDE and editor files
 .vscode/
 .idea/

--- a/app/api/career-guidelines/generate/route.ts
+++ b/app/api/career-guidelines/generate/route.ts
@@ -56,7 +56,8 @@ export async function POST(request: NextRequest) {
       role, 
       level: nextLevel, 
       companyLadder,
-      currentLevelGuidelines: currentLevelResponse.content.trim()
+      currentLevelGuidelines: currentLevelResponse.content.trim(),
+      currentLevel: level
     })
     
     const nextLevelResponse = await llmProxy.request({

--- a/app/api/jobs/career-plan/career-plan-prompt.ts
+++ b/app/api/jobs/career-plan/career-plan-prompt.ts
@@ -10,13 +10,14 @@ export interface CareerPlanPromptContext {
   level: string
   companyLadder?: string
   currentLevelGuidelines?: string
+  currentLevel?: string
 }
 
 /**
  * Build career plan generation prompt using the provided Gemini prompt
  */
 export function buildCareerPlanPrompt(context: CareerPlanPromptContext): string {
-  const { role, level, companyLadder, currentLevelGuidelines } = context
+  const { role, level, companyLadder, currentLevelGuidelines, currentLevel } = context
   
   return `## CONTEXT
 You are an expert career management assistant for "AdvanceWeekly," a SaaS platform designed to help technology professionals (engineers, product managers, designers, etc.) track and foster their career growth. Our brand is thoughtful, pragmatic, and respects that users are busy. We avoid corporate jargon and focus on actionable, realistic guidance.
@@ -31,12 +32,12 @@ You will be provided with the following user information:
 ${companyLadder ? `3. **Company Context**: ${companyLadder}` : ''}
 ${currentLevelGuidelines ? `
 ## REFERENCE CONTEXT
-The following guidelines have been generated for the current level (${level}). Use these as reference to ensure a natural progression and consistency when generating guidelines for the next level:
+The following guidelines have been generated for the current level (${currentLevel || level}). Use these as reference to ensure a natural progression and consistency when generating guidelines for the target level (${level}):
 
 ${currentLevelGuidelines}
 
-When generating expectations for the next level, ensure they:
-- Build upon and extend the current level expectations
+When generating expectations for the target level (${level}), ensure they:
+- Build upon and extend the current level (${currentLevel || level}) expectations
 - Show clear progression in scope, complexity, and leadership
 - Maintain consistency in terminology and focus areas
 - Demonstrate increased responsibility and impact


### PR DESCRIPTION
## Summary
Fixed career guidelines generation prompt confusion where next level generation incorrectly referenced the target level as "current level" in the AI prompt context.

## Problem
When generating career guidelines for the next level, the prompt template incorrectly referred to the current level as the next level, which likely confused the AI model and led to inconsistent or incorrect guidelines.

**Code flow issue:**
1. Generate guidelines for current level (e.g., "Senior") 
2. Get next level using `getNextSeniorityLevel()` (e.g., "Staff")
3. Call `buildCareerPlanPrompt()` with `level: nextLevel` (Staff)
4. In prompt template, it said: "current level (Staff)" instead of "current level (Senior)"

## Solution
- Add `currentLevel` parameter to `CareerPlanPromptContext` interface
- Update `buildCareerPlanPrompt` to distinguish between current and target levels  
- Modify career guidelines route to pass actual current level when generating next level
- Improve prompt clarity with explicit current level vs target level references

## Changes
- **app/api/jobs/career-plan/career-plan-prompt.ts**: Enhanced interface and fixed prompt template
- **app/api/career-guidelines/generate/route.ts**: Updated to pass currentLevel parameter

## Test plan
- [x] Verified TypeScript compilation passes
- [x] Confirmed prompt template uses correct level references
- [x] Validated career guidelines route passes currentLevel parameter  
- [x] All pre-commit checks pass
- [x] API tests continue to pass

## Impact
This ensures the AI model receives clear context about progression from the user's actual current level to their target level, preventing confusion and improving guideline generation accuracy.

Fixes #79

🤖 Generated with [Claude Code](https://claude.ai/code)