### PR TITLE
Fix: Always generate Prisma client before applying database schema

### DIFF
--- a/scripts/apply-database-schema.sh
+++ b/scripts/apply-database-schema.sh
@@ -21,11 +21,9 @@ echo "🔍 Environment: ${NODE_ENV:-production}"
 echo "📡 Database URL: ${DATABASE_URL%%password*}[REDACTED]"
 echo ""
 
-# Generate Prisma client if needed
-if [ ! -d "node_modules/@prisma/client" ]; then
-    echo "📦 Generating Prisma client..."
-    npx prisma generate
-fi
+# Always generate Prisma client to ensure it's up to date
+echo "📦 Generating Prisma client..."
+npx prisma generate
 
 # Apply database schema
 echo "🗄️  Applying database schema..."


### PR DESCRIPTION
## Problem
The staging deployment was failing with:
```
Error: Cannot find module '.prisma/client/default'
```

This was happening because the Prisma client wasn't being generated properly in the GitHub Actions environment.

## Root Cause
The `apply-database-schema.sh` script was only generating the Prisma client if the directory didn't exist. However, in GitHub Actions, the directory exists but contains an empty/invalid client after `npm ci`.

## Solution
Always generate the Prisma client fresh before attempting to apply the database schema. This ensures the client is properly built for the current environment.

## Changes
- Modified `scripts/apply-database-schema.sh` to always run `npx prisma generate`
- Removed the conditional check that was skipping generation

## Testing
- This will be tested when the staging deployment runs after merging
- The deployment should now successfully:
  1. Generate Prisma client
  2. Apply database schema
  3. Seed career guidelines
  4. Initialize staging mock users

Fixes the staging database initialization issue discovered in deployment #16953001251