### PR TITLE
Fix: Enable devtools reset onboarding button in staging environment

### DIFF
--- a/__tests__/devtools-reset-onboarding.test.ts
+++ b/__tests__/devtools-reset-onboarding.test.ts
@@ -72,7 +72,7 @@ describe('DELETE /api/user/onboarding (Reset Onboarding)', () => {
     const data = await response.json()
 
     expect(response.status).toBe(403)
-    expect(data.error).toBe('This endpoint is only available in development')
+    expect(data.error).toBe('This endpoint is only available in development and staging environments')
   })
 
   it('should return 401 if not authenticated', async () => {

--- a/__tests__/reset-onboarding.test.ts
+++ b/__tests__/reset-onboarding.test.ts
@@ -78,7 +78,7 @@ describe('Reset Onboarding Functionality', () => {
       const data = await response.json()
 
       expect(response.status).toBe(403)
-      expect(data.error).toBe('This endpoint is only available in development')
+      expect(data.error).toBe('This endpoint is only available in development and staging environments')
       expect(mockGetUserIdFromRequest).not.toHaveBeenCalled()
     })
 

--- a/app/api/user/onboarding/route.ts
+++ b/app/api/user/onboarding/route.ts
@@ -2,12 +2,17 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getUserIdFromRequest } from '../../../../lib/auth-utils'
 import { getDevUserIdFromRequest } from '../../../../lib/dev-auth'
 import { createUserDataService } from '../../../../lib/user-scoped-data'
+import { isDevLike } from '../../../../lib/environment'
+
+// Force dynamic execution for environment detection
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
 
 export async function POST(request: NextRequest) {
   try {
-    // Get authenticated user ID from session (with dev fallback)
+    // Get authenticated user ID from session (with dev fallback for dev-like environments)
     let userId = await getUserIdFromRequest(request)
-    if (!userId && process.env.NODE_ENV === 'development') {
+    if (!userId && isDevLike()) {
       userId = await getDevUserIdFromRequest(request)
     }
     if (!userId) {
@@ -52,18 +57,18 @@ export async function POST(request: NextRequest) {
 }
 
 export async function DELETE(request: NextRequest) {
-  // Only allow in development
-  if (process.env.NODE_ENV !== 'development') {
+  // Only allow in dev-like environments (development + staging)
+  if (!isDevLike()) {
     return NextResponse.json(
-      { error: 'This endpoint is only available in development' },
+      { error: 'This endpoint is only available in development and staging environments' },
       { status: 403 }
     )
   }
 
   try {
-    // Get authenticated user ID from session (with dev fallback)
+    // Get authenticated user ID from session (with dev fallback for dev-like environments)
     let userId = await getUserIdFromRequest(request)
-    if (!userId && process.env.NODE_ENV === 'development') {
+    if (!userId && isDevLike()) {
       userId = await getDevUserIdFromRequest(request)
     }
     if (!userId) {


### PR DESCRIPTION
## Summary
- Fix devtools reset onboarding button not working on staging
- Replace incorrect NODE_ENV check with proper isDevLike() function
- Enable staging support for onboarding reset functionality

## Problem Analysis
The "Reset Onboarding" button in DevTools was failing on staging with a 403 error because:

```typescript
// ❌ Previous code (staging has NODE_ENV=staging, not development)
if (process.env.NODE_ENV !== 'development') {
  return 403
}
```

Staging uses `NODE_ENV=staging`, so this check incorrectly blocked the request.

## Root Cause
- **Environment Detection**: API route used hardcoded NODE_ENV check instead of environment library
- **Inconsistent Logic**: DevTools component correctly uses `isDevLike()` but API route didn't
- **Missing Dynamic Exports**: API route was susceptible to Next.js build-time caching

## Solution

### API Route Updates (`app/api/user/onboarding/route.ts`):

#### ✅ **Proper Environment Detection**:
```typescript
// ✅ New code (works for both development and staging)  
import { isDevLike } from '../../../../lib/environment'

if (!isDevLike()) {
  return 403
}
```

#### ✅ **Next.js Dynamic Execution**:
```typescript
export const dynamic = 'force-dynamic'
export const revalidate = 0
```

#### ✅ **Consistent Auth Fallback**:
```typescript
// Both POST and DELETE now use isDevLike() consistently
if (!userId && isDevLike()) {
  userId = await getDevUserIdFromRequest(request)
}
```

## Technical Benefits
- 🎯 **Correct Environment Logic**: Uses shared environment detection library
- 🚀 **Runtime Execution**: Prevents Next.js build-time caching issues
- 🔄 **Consistent Behavior**: Same logic as DevTools component and other parts of app
- 📝 **Better Error Messages**: Clear indication of dev + staging support

## Expected Behavior Changes
| Environment | Before | After |
|-------------|--------|-------|
| **Development** | ✅ Works | ✅ Works (unchanged) |
| **Staging** | ❌ 403 Error | ✅ Works (fixed) |
| **Production** | ❌ Hidden UI | ❌ Hidden UI (unchanged) |

## Test Plan
- [x] ✅ **Root Cause Analysis**: Identified NODE_ENV vs staging issue
- [x] ✅ **Implementation**: Used proper isDevLike() function with dynamic exports
- [ ] 🧪 **Staging Deployment**: Deploy fix and test reset onboarding button
- [ ] ✅ **Functional Test**: Verify button resets user onboarding status
- [ ] 🔄 **Flow Test**: Confirm redirect to onboarding wizard works correctly

## Context
This fix maintains the security posture (production still blocked) while enabling the intended development experience in staging. The staging environment serves as a production-like testing ground where developers need access to reset functionality for testing onboarding flows.

🤖 Generated with [Claude Code](https://claude.ai/code)