### PR TITLE
Fix: Correct staging environment redirect paths causing 404 errors

### DIFF
--- a/components/DevTools.tsx
+++ b/components/DevTools.tsx
@@ -90,7 +90,7 @@ export function DevTools() {
       
       // Clear NextAuth session (important for staging JWT cookies)
       console.log('🔄 Clearing NextAuth session...')
-      const redirectUrl = envMode === 'staging' ? '/staging' : '/'
+      const redirectUrl = '/'
       await signOut({ 
         redirect: false,
         callbackUrl: redirectUrl
@@ -102,7 +102,7 @@ export function DevTools() {
     } catch (error) {
       console.error('Error clearing session:', error)
       // Fallback: force reload anyway
-      window.location.href = envMode === 'staging' ? '/staging' : '/'
+      window.location.href = '/'
     }
   }
 
@@ -159,7 +159,7 @@ export function DevTools() {
         const data = await response.json()
         const confirmRedirect = confirm('Onboarding reset successfully! Would you like to go to the onboarding wizard now?')
         if (confirmRedirect) {
-          window.location.href = envMode === 'staging' ? '/staging' : '/onboarding-wizard'
+          window.location.href = envMode === 'staging' ? '/' : '/onboarding-wizard'
         }
       } else {
         const error = await response.json().catch(() => ({ error: 'Unknown error' }))
@@ -188,7 +188,7 @@ export function DevTools() {
       
       if (response.ok) {
         alert('Staging data reset successfully! Redirecting to staging home...')
-        window.location.href = '/staging'
+        window.location.href = '/'
       } else {
         const error = await response.json().catch(() => ({ error: 'Unknown error' }))
         alert(`Failed to reset staging data: ${error.error}`)
@@ -199,7 +199,7 @@ export function DevTools() {
   }
 
   const goToOnboarding = () => {
-    window.location.href = envMode === 'staging' ? '/staging' : '/onboarding-wizard'
+    window.location.href = envMode === 'staging' ? '/' : '/onboarding-wizard'
   }
 
   const goToDashboard = () => {
@@ -207,7 +207,7 @@ export function DevTools() {
     // Set flags to ensure we bypass onboarding
     localStorage.setItem('onboarding-just-completed', 'true')
     localStorage.setItem('onboarding-completed-timestamp', Date.now().toString())
-    window.location.href = envMode === 'staging' ? '/staging' : '/'
+    window.location.href = '/'
   }
 
   return (


### PR DESCRIPTION
## Summary
• Fix 404 errors when clicking DevTools reset onboarding button in staging
• Correct all redirect paths from '/staging' to '/' for staging environment
• Ensure proper navigation flow after DevTools actions

## Problem
When clicking the "Reset" button in DevTools on staging environment, users encountered:
```
404 - This page could not be found.
```

## Root Cause
The DevTools component was using `/staging` paths for redirects, but staging environment runs on `staging.advanceweekly.io` domain where all paths should be relative to root `/`.

## Solution
Updated all DevTools redirect logic:
- **Reset onboarding success**: `'/staging'` → `'/'`
- **Clear session**: `'/staging'` → `'/'` 
- **Reset staging data**: `'/staging'` → `'/'`
- **Go to onboarding**: `'/staging'` → `'/'`
- **Go to dashboard**: `'/staging'` → `'/'`

## Changes Made
- Fixed `resetOnboarding()` redirect after successful reset
- Simplified `clearSession()` to always use root path
- Updated `resetStagingData()` success redirect  
- Corrected `goToOnboarding()` staging path
- Fixed `goToDashboard()` redirect logic

## Test Plan
- [x] Development: All redirects work on localhost
- [ ] Staging: Reset button now navigates correctly without 404s
- [x] Production: DevTools remain properly hidden

🤖 Generated with [Claude Code](https://claude.ai/code)